### PR TITLE
Avoid drawing one circle twice

### DIFF
--- a/src/00-Foreword.coffee
+++ b/src/00-Foreword.coffee
@@ -18,7 +18,7 @@ webpage = kup.render ->
             ctx.stroke()
           ctx.strokeStyle = 'rgba(255,40,20,0.7)'
           circle ctx, x, y
-          for angle in [0...2*Math.PI] by 1/3*Math.PI
+          for angle in [0...5/3*Math.PI] by 1/3*Math.PI
             circle ctx, x+100*Math.cos(angle),
                         y+100*Math.sin(angle)
         window.onload = ->


### PR DESCRIPTION
Nitpick - By looping from 0 to 2π (inclusive) it draws twice at 0. This is actually noticeable - The rightmost ring is thicker than the others (at least when rendered in Firefox 11.0).
